### PR TITLE
fix: pin axios to exact version 1.7.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@iframe-resizer/react": "^5.2.1",
-    "axios": "^1.7.7",
+    "axios": "1.7.7",
     "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",
     "react-datetime-picker": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@formant/view-embed-react-wrapper",
   "homepage": "http://formantio.github.io/view-embed-react-wrapper",
   "private": false,
-  "version": "1.5.0",
+  "version": "1.5.2",
   "type": "module",
   "main": "dist/index.umd.js",
   "module": "dist/index.es.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2405,7 +2405,7 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^1.7.7:
+axios@1.7.7:
   version "1.7.7"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.7.tgz#2f554296f9892a72ac8d8e4c5b79c14a91d0a47f"
   integrity sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==


### PR DESCRIPTION
Removes caret from axios dependency to pin to exact version 1.7.7, preventing accidental resolution to compromised versions (1.14.1, 0.30.4) on fresh installs.

Ref: [StepSecurity axios supply chain attack report](https://www.stepsecurity.io/blog/axios-npm-supply-chain-attack-drops-rat)