### PR TITLE
fix(build): externalize react/jsx-runtime to support React 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@formant/view-embed-react-wrapper",
   "homepage": "http://formantio.github.io/view-embed-react-wrapper",
   "private": false,
-  "version": "1.5.2",
+  "version": "1.5.3",
   "type": "module",
   "main": "dist/index.umd.js",
   "module": "dist/index.es.js",
@@ -37,8 +37,8 @@
     "short-uuid": "^5.2.0"
   },
   "peerDependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^18.3.1 || ^19.0.0",
+    "react-dom": "^18.3.1 || ^19.0.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.24.7",

--- a/src/ViewEmbedWrapper.test.tsx
+++ b/src/ViewEmbedWrapper.test.tsx
@@ -51,7 +51,7 @@ describe("ViewEmbedWrapper Component", () => {
     expect(iframe).toHaveAttribute("name", "rectangle-app-test-iframe-id");
     expect(iframe).toHaveAttribute(
       "src",
-      "https://embed.formant.io?iframeId=test-iframe-id"
+      "https://embed.formant.io?iframeId=test-iframe-id",
     );
   });
 
@@ -73,23 +73,26 @@ describe("ViewEmbedWrapper Component", () => {
     iframe.dispatchEvent(new Event("load"));
 
     expect(mockPostMessage).toHaveBeenCalledWith(
-      JSON.stringify({
-        messageType: "viewEmbedLoad",
-        viewId: "test-view-id",
-        deviceIds: ["device1", "device2"],
-        themeOverride: {
-          "formant-color-primary-white": "#000000",
-          "formant-color-primary-silver": "#1F1F1F",
-        },
-        authToken: "test-auth-token",
-        currentDate: new Date("2024-10-21T00:00:00Z").toISOString(),
-        timeRange: "30 minutes",
-        aggregation: "1d",
-        aggregateStartDate: new Date("2024-10-20T00:00:00Z").toISOString(),
-        aggregateEndDate: new Date("2024-10-21T00:00:00Z").toISOString(),
-      }),
-      "*"
+      expect.stringContaining('"messageType":"viewEmbedLoad"'),
+      "*",
     );
+
+    const loadCall = mockPostMessage.mock.calls.find(([msg]: [string]) =>
+      msg.includes('"viewEmbedLoad"'),
+    );
+    expect(loadCall).toBeDefined();
+    const payload = JSON.parse(loadCall![0]);
+    expect(payload).toMatchObject({
+      messageType: "viewEmbedLoad",
+      viewId: mockProps.viewId,
+      deviceIds: mockProps.deviceIds,
+      themeOverride: mockProps.themeOverride,
+      authToken: mockProps.authToken,
+      timeRange: mockProps.timeRange,
+      aggregation: mockProps.aggregation,
+      dataSrcUrl: mockProps.dataSrcUrl,
+      apiBaseUrl: mockProps.apiBaseUrl,
+    });
   });
 
   it('sends "viewEmbedUpdate" message on prop change', () => {
@@ -103,26 +106,22 @@ describe("ViewEmbedWrapper Component", () => {
 
     rerender(<ViewEmbedWrapper {...updatedProps} />);
 
-    expect(mockPostMessage).toHaveBeenCalledWith(
-      JSON.stringify({
-        messageType: "viewEmbedUpdate",
-        viewId: "updated-view-id",
-        deviceIds: ["device1", "device2"],
-        dataSrcUrl: "https://embed.formant.io",
-        authToken: "test-auth-token",
-        currentDate: new Date("2024-10-21T00:00:00Z").toISOString(),
-        timeRange: "1 hour",
-        aggregation: "1d",
-        aggregateStartDate: new Date("2024-10-20T00:00:00Z").toISOString(),
-        aggregateEndDate: new Date("2024-10-21T00:00:00Z").toISOString(),
-        themeOverride: {
-          "formant-color-primary-white": "#000000",
-          "formant-color-primary-silver": "#1F1F1F",
-        },
-        viewTags: undefined,
-        apiBaseUrl: "https://api.formant.io",
-      }),
-      "*"
+    const updateCalls = mockPostMessage.mock.calls.filter(([msg]: [string]) =>
+      msg.includes('"viewEmbedUpdate"'),
     );
+    const lastUpdate = updateCalls[updateCalls.length - 1];
+    expect(lastUpdate).toBeDefined();
+    const payload = JSON.parse(lastUpdate![0]);
+    expect(payload).toMatchObject({
+      messageType: "viewEmbedUpdate",
+      viewId: "updated-view-id",
+      deviceIds: mockProps.deviceIds,
+      dataSrcUrl: mockProps.dataSrcUrl,
+      authToken: mockProps.authToken,
+      timeRange: "1 hour",
+      aggregation: mockProps.aggregation,
+      themeOverride: mockProps.themeOverride,
+      apiBaseUrl: mockProps.apiBaseUrl,
+    });
   });
 });

--- a/src/ViewEmbedWrapper.test.tsx
+++ b/src/ViewEmbedWrapper.test.tsx
@@ -88,8 +88,11 @@ describe("ViewEmbedWrapper Component", () => {
       deviceIds: mockProps.deviceIds,
       themeOverride: mockProps.themeOverride,
       authToken: mockProps.authToken,
+      currentDate: mockProps.currentDate.toISOString(),
       timeRange: mockProps.timeRange,
       aggregation: mockProps.aggregation,
+      aggregateStartDate: mockProps.aggregateStartDate.toISOString(),
+      aggregateEndDate: mockProps.aggregateEndDate.toISOString(),
       dataSrcUrl: mockProps.dataSrcUrl,
       apiBaseUrl: mockProps.apiBaseUrl,
     });
@@ -118,8 +121,11 @@ describe("ViewEmbedWrapper Component", () => {
       deviceIds: mockProps.deviceIds,
       dataSrcUrl: mockProps.dataSrcUrl,
       authToken: mockProps.authToken,
+      currentDate: mockProps.currentDate.toISOString(),
       timeRange: "1 hour",
       aggregation: mockProps.aggregation,
+      aggregateStartDate: mockProps.aggregateStartDate.toISOString(),
+      aggregateEndDate: mockProps.aggregateEndDate.toISOString(),
       themeOverride: mockProps.themeOverride,
       apiBaseUrl: mockProps.apiBaseUrl,
     });

--- a/test/buildOutput.test.ts
+++ b/test/buildOutput.test.ts
@@ -1,0 +1,57 @@
+import * as fs from "fs";
+import * as path from "path";
+
+describe("Build output", () => {
+  const distDir = path.resolve(__dirname, "../dist");
+  const esModule = path.join(distDir, "index.es.js");
+  const umdModule = path.join(distDir, "index.umd.js");
+
+  it("dist files exist", () => {
+    expect(fs.existsSync(esModule)).toBe(true);
+    expect(fs.existsSync(umdModule)).toBe(true);
+  });
+
+  describe("ES module does not bundle React internals", () => {
+    let content: string;
+
+    beforeAll(() => {
+      content = fs.readFileSync(esModule, "utf-8");
+    });
+
+    it("does not contain __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED", () => {
+      expect(content).not.toContain(
+        "__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED",
+      );
+    });
+
+    it("does not contain bundled react-jsx-runtime source", () => {
+      expect(content).not.toContain("react-jsx-runtime.production");
+    });
+
+    it("imports jsx-runtime as an external module", () => {
+      expect(content).toContain('from "react/jsx-runtime"');
+    });
+
+    it("imports react as an external module", () => {
+      expect(content).toContain('from "react"');
+    });
+  });
+
+  describe("UMD module does not bundle React internals", () => {
+    let content: string;
+
+    beforeAll(() => {
+      content = fs.readFileSync(umdModule, "utf-8");
+    });
+
+    it("does not contain __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED", () => {
+      expect(content).not.toContain(
+        "__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED",
+      );
+    });
+
+    it("does not contain bundled react-jsx-runtime source", () => {
+      expect(content).not.toContain("react-jsx-runtime.production");
+    });
+  });
+});

--- a/utils/embedWithHooks.test.tsx
+++ b/utils/embedWithHooks.test.tsx
@@ -5,7 +5,7 @@ import { ViewEmbedWrapper } from "../src/ViewEmbedWrapper";
 import { EmbedWithHooks } from "./embedWithHooks";
 import { useAuthToken } from "./useAuthToken";
 
-jest.mock("../ViewEmbedWrapper", () => ({
+jest.mock("../src/ViewEmbedWrapper", () => ({
   ViewEmbedWrapper: jest.fn(() => (
     <div data-testid="view-embed-wrapper">ViewEmbedWrapper</div>
   )),
@@ -31,7 +31,7 @@ describe("EmbedWithHooks Component", () => {
     serviceAccountPassword: "password",
     apiBaseUrl: "https://api.formant.io",
     authScope: { tags: { role: ["admin"] } },
-    roleId: ""
+    roleId: "",
   };
 
   beforeEach(() => {
@@ -46,11 +46,11 @@ describe("EmbedWithHooks Component", () => {
     expect(screen.getByText("Unauthorized.")).toBeInTheDocument();
     expect(
       screen.getByText(
-        /Enter a valid authentication token, or enter a serviceAccountEmail, serviceAccountPassword, authScope and roleId/
-      )
+        /Enter a valid authentication token, or enter a serviceAccountEmail, serviceAccountPassword, authScope and roleId/,
+      ),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("Embed a Formant view in an external site")
+      screen.getByText("Embed a Formant view in an external site"),
     ).toBeInTheDocument();
   });
 
@@ -78,7 +78,7 @@ describe("EmbedWithHooks Component", () => {
         pageLayoutBelowContent={
           <div data-testid="below-content">Below Content</div>
         }
-      />
+      />,
     );
 
     expect(screen.getByTestId("above-content")).toBeInTheDocument();
@@ -102,7 +102,7 @@ describe("EmbedWithHooks Component", () => {
         dataSrcUrl: "https://embed.formant.io",
         viewTags: undefined,
       }),
-      {}
+      {},
     );
   });
 
@@ -115,7 +115,7 @@ describe("EmbedWithHooks Component", () => {
         // @ts-ignore
         aggregateEndDate={1672617600000} // equivalent to 2023-01-02T00:00:00Z
         providedAuthToken="test-token"
-      />
+      />,
     );
 
     expect(ViewEmbedWrapper).toHaveBeenCalledWith(
@@ -123,7 +123,7 @@ describe("EmbedWithHooks Component", () => {
         aggregateStartDate: new Date(1672531200000),
         aggregateEndDate: new Date(1672617600000),
       }),
-      {}
+      {},
     );
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,11 +12,12 @@ export default defineConfig({
       fileName: (format) => `index.${format}.js`,
     },
     rollupOptions: {
-      external: ["react", "react-dom"],
+      external: ["react", "react-dom", "react/jsx-runtime"],
       output: {
         globals: {
           react: "React",
           "react-dom": "ReactDOM",
+          "react/jsx-runtime": "ReactJSXRuntime",
         },
       },
     },


### PR DESCRIPTION
## Problem

The published package bundles a copy of React 18's `jsx-runtime` into `dist/index.es.js`. That bundled code accesses `React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner`, which React 19 renamed to `__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE`. This causes an immediate crash when used in a React 19 app:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'ReactCurrentOwner')
```

## Root Cause

`vite.config.ts` externalizes `"react"` and `"react-dom"` but not `"react/jsx-runtime"`. Rollup treats subpaths as separate modules (string match, not package resolution), so it bundled the entire `react/jsx-runtime.js` file (600+ lines of React 18 internals) into the dist output.

## Changes

| File | Change |
|------|--------|
| `vite.config.ts` | Add `"react/jsx-runtime"` to `rollupOptions.external` |
| `package.json` | Bump version 1.5.2 → 1.5.3, widen peerDependencies to `^18.3.1 \|\| ^19.0.0` |
| `src/ViewEmbedWrapper.test.tsx` | Fix pre-existing failures: missing payload fields, hardcoded values → `mockProps` refs |
| `utils/embedWithHooks.test.tsx` | Fix pre-existing failure: mock path `../ViewEmbedWrapper` → `../src/ViewEmbedWrapper` |
| `test/buildOutput.test.ts` | New regression test: verifies dist output does not bundle React internals |

## Backwards Compatibility

This change is fully backwards compatible with existing React 18 consumers.

- **Externalization:** Previously the wrapper bundled React 18's jsx-runtime; now it imports from the host app's React. For React 18 apps, the host provides the same jsx-runtime that was previously bundled — functionally identical.
- **peerDependencies:** Range goes from `^18.3.1` to `^18.3.1 || ^19.0.0`. Existing consumers remain in range.
- **Bundle size:** Dist drops from 41KB / 1,211 lines to 20KB / 590 lines. The removed code is entirely React 18's jsx-runtime — none of the wrapper's own logic is affected.

This is the standard approach — `@tanstack/react-query`, `react-router-dom`, and `framer-motion` all externalize `react/jsx-runtime`. The `react/jsx-runtime` subpath has shipped with the `react` package since React 17 (October 2020).

## Verified

Tested locally against [FormantIO/qa-exbed](https://github.com/FormantIO/qa-exbed) React 19 app:
- Home page renders (login form)
- Embedded view loads with auth token and Holman theme
- Zero console errors
- 17/17 tests passing